### PR TITLE
Force Travis to use OS X 10.12 (Sierra) to fix Safari tests

### DIFF
--- a/wct.conf.js
+++ b/wct.conf.js
@@ -1,12 +1,12 @@
 module.exports = {
   "plugins": {
     "sauce": {
-      "disabled": true, 
+      "disabled": true,
       "browsers": [
         "Windows 8.1/internet explorer",
         "Windows 10/microsoftedge",
-        "OS X 10.10/safari"
+        "OS X 10.12/safari"
     ]
     }
   }
-}
+};


### PR DESCRIPTION
Force Travis to use OS X 10.12 (Sierra) to fix Safari tests.