### PR TITLE
Adjust not tagged icon position on mobile

### DIFF
--- a/fs-artifact-list-item.html
+++ b/fs-artifact-list-item.html
@@ -427,7 +427,7 @@ Example:
         }
         .tag-note {
           top: -23px;
-          right: -5px;
+          right: 5px;
         }
         .comment-note {
           top: 20px;


### PR DESCRIPTION
Adjust not tagged icon position on mobile so it is not cut off on the right side.