### PR TITLE
Prevent navigation in select mode

### DIFF
--- a/fs-artifact-list-item.html
+++ b/fs-artifact-list-item.html
@@ -758,7 +758,7 @@ Example:
         this.fire('list-item-mouseout');
       },
       _titleLinkOverride: function(e) {
-        if (this.data.tombstoned) {
+        if (this.selectMode || this.data.tombstoned) {
           e.preventDefault();
           return;
         }


### PR DESCRIPTION
When in select mode, prevent navigation to an artifact when clicking on the title.

@chadeddington / @jpodwys / @ta1188 