### PR TITLE
Fixing list-view overflow issue

### DIFF
--- a/fs-artifact-list-item.html
+++ b/fs-artifact-list-item.html
@@ -348,6 +348,10 @@ Example:
           white-space: nowrap;
           text-overflow: ellipsis;
         }
+        #container .place-text {
+          /* Required for non-chrome browsers to actually show ellipsis */
+          display: inline;
+        }
         .col-1 {
           width: 38%;
         }

--- a/fs-artifact-list-item.html
+++ b/fs-artifact-list-item.html
@@ -536,7 +536,7 @@ Example:
         <div class='col col-2' hidden='[[_showMobileMessage(_displayMessage, mobile)]]'>
           <div class='date'>
             <template is='dom-if' if='[[!data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=date' class='date-text' title='[[_getDate(data.datesPlaces.0)]]' on-tap='_stopProp' hidden='[[!_hideDateElements(data.datesPlaces.0)]]'>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=date' class='date-text' on-tap='_stopProp' hidden='[[!_hideDateElements(data.datesPlaces.0)]]'>
                 <span>[[_getDate(data.datesPlaces.0)]]</span>
               </a>
             </template>
@@ -551,12 +551,12 @@ Example:
           </div>
           <div class='place'>
             <template is='dom-if' if='[[!data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' title='[[_getPlace(data.datesPlaces.0)]]' on-tap='_stopProp'>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopProp'>
                 <span> [[_getPlace(data.datesPlaces.0)]]</span>
               </a>
             </template>
             <template is='dom-if' if='[[data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place' title='[[_getPlace(data.datesPlaces.0)]]'>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place'>
                 <span>[[_getPlace(data.datesPlaces.0)]]</span>
               </a>
               <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='add-styles' hidden='[[_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place'>
@@ -568,7 +568,7 @@ Example:
         <div class='col col-3' hidden='[[_showMobileMessage(_displayMessage, mobile)]]'>
           <div class='place'>
             <template is='dom-if' if='[[!data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' title='[[_getPlace(data.datesPlaces.0)]]' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopProp'>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopProp'>
                 <span> [[_getPlace(data.datesPlaces.0)]]</span>
               </a>
             </template>

--- a/fs-artifact-list-item.html
+++ b/fs-artifact-list-item.html
@@ -343,6 +343,11 @@ Example:
           padding-left: 10px;
           height: 58px;
         }
+        #container .place {
+          overflow: hidden;
+          white-space: nowrap;
+          text-overflow: ellipsis;
+        }
         .col-1 {
           width: 38%;
         }

--- a/fs-artifact-list-item.html
+++ b/fs-artifact-list-item.html
@@ -42,7 +42,7 @@ Example:
         margin: 0;
       }
 
-      [hidden] {
+      *[hidden] {
         display: none !important;
       }
 
@@ -57,7 +57,7 @@ Example:
         margin-bottom: 1px;
         padding: 4px 13px 0px 48px;
         box-sizing: border-box;
-        @apply(--list-item-container-styles);
+        @apply --list-item-container-styles;
       }
       #container .add-styles:visited {
         color: #0060d7;
@@ -293,7 +293,7 @@ Example:
       }
 
       .info-icon {
-        background-image: url(data:image/svg+xml;charset=utf-8, %3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.2%22%20baseProfile%3D%22tiny%22%20x%3D%220%22%20y%3D%220%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2020%2020%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20fill%3D%22%23FFFFFF%22%20d%3D%22M10%2018.7c-4.8%200-8.7-3.9-8.7-8.7%200-4.8%203.9-8.7%208.7-8.7%204.8%200%208.7%203.9%208.7%208.7C18.7%2014.8%2014.8%2018.7%2010%2018.7zM9.1%207.4c-0.4%200-0.9%200.1-1.3%200.2C7.1%207.9%206.9%208.4%206.9%208.8%207%209.1%207.2%209.3%207.4%209.3c0.4%200%200.5%200.1%200.6%200.1%200%200%200.1%200.1%200.1%200.5%200%200.2%200%200.3-0.1%200.5%200%200.2-0.1%200.4-0.2%200.7l-0.7%202.5c-0.1%200.3-0.1%200.5-0.1%200.8%200%200.2%200%200.4%200%200.7%200%200.6%200.2%201.1%200.7%201.5C7.9%2016.7%208.5%2017.2%209.5%2017.2c0.5%200%201.2-0.2%201.7-0.4%200.5-0.2%200.9-0.6%200.9-1%200-0.2-0.1-0.4-0.2-0.6%20-0.1-0.1-0.2-0.1-0.3-0.1%20-0.1%200-0.3%200.1-0.4%200.1l-0.1%200c-0.4%200-0.5-0.1-0.6-0.1%200%200-0.1-0.2-0.1-0.4%200-0.1%200-0.3%200.1-0.5%200-0.2%200.1-0.5%200.1-0.7l0.7-2.5c0.1-0.3%200.1-0.5%200.2-0.8%200-0.3%200-0.5%200-0.6%200-0.6-0.2-1.1-0.7-1.5C10.4%207.6%209.8%207.4%209.1%207.4zM10.7%202.8c-0.5%200-1%200.2-1.4%200.5C8.8%203.7%208.6%204.2%208.6%204.7c0%200.5%200.2%201%200.6%201.4%200.4%200.4%200.9%200.5%201.4%200.5%200.5%200%201-0.2%201.4-0.5%200.4-0.4%200.6-0.8%200.6-1.3%200-0.5-0.2-1-0.6-1.3C11.7%203%2011.2%202.8%2010.7%202.8z%22%2F%3E%3Crect%20fill%3D%22none%22%20width%3D%2220%22%20height%3D%2220%22%2F%3E%3C%2Fsvg%3E%0D%0A);
+        background-image: url('data:image/svg+xml;charset=utf-8, %3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20version%3D%221.2%22%20baseProfile%3D%22tiny%22%20x%3D%220%22%20y%3D%220%22%20width%3D%2220%22%20height%3D%2220%22%20viewBox%3D%220%200%2020%2020%22%20xml%3Aspace%3D%22preserve%22%3E%3Cpath%20fill%3D%22%23FFFFFF%22%20d%3D%22M10%2018.7c-4.8%200-8.7-3.9-8.7-8.7%200-4.8%203.9-8.7%208.7-8.7%204.8%200%208.7%203.9%208.7%208.7C18.7%2014.8%2014.8%2018.7%2010%2018.7zM9.1%207.4c-0.4%200-0.9%200.1-1.3%200.2C7.1%207.9%206.9%208.4%206.9%208.8%207%209.1%207.2%209.3%207.4%209.3c0.4%200%200.5%200.1%200.6%200.1%200%200%200.1%200.1%200.1%200.5%200%200.2%200%200.3-0.1%200.5%200%200.2-0.1%200.4-0.2%200.7l-0.7%202.5c-0.1%200.3-0.1%200.5-0.1%200.8%200%200.2%200%200.4%200%200.7%200%200.6%200.2%201.1%200.7%201.5C7.9%2016.7%208.5%2017.2%209.5%2017.2c0.5%200%201.2-0.2%201.7-0.4%200.5-0.2%200.9-0.6%200.9-1%200-0.2-0.1-0.4-0.2-0.6%20-0.1-0.1-0.2-0.1-0.3-0.1%20-0.1%200-0.3%200.1-0.4%200.1l-0.1%200c-0.4%200-0.5-0.1-0.6-0.1%200%200-0.1-0.2-0.1-0.4%200-0.1%200-0.3%200.1-0.5%200-0.2%200.1-0.5%200.1-0.7l0.7-2.5c0.1-0.3%200.1-0.5%200.2-0.8%200-0.3%200-0.5%200-0.6%200-0.6-0.2-1.1-0.7-1.5C10.4%207.6%209.8%207.4%209.1%207.4zM10.7%202.8c-0.5%200-1%200.2-1.4%200.5C8.8%203.7%208.6%204.2%208.6%204.7c0%200.5%200.2%201%200.6%201.4%200.4%200.4%200.9%200.5%201.4%200.5%200.5%200%201-0.2%201.4-0.5%200.4-0.4%200.6-0.8%200.6-1.3%200-0.5-0.2-1-0.6-1.3C11.7%203%2011.2%202.8%2010.7%202.8z%22%2F%3E%3Crect%20fill%3D%22none%22%20width%3D%2220%22%20height%3D%2220%22%2F%3E%3C%2Fsvg%3E%0D%0A');
         background-position: center;
         background-repeat: no-repeat;
         background-size: contain;
@@ -343,15 +343,6 @@ Example:
           padding-left: 10px;
           height: 58px;
         }
-        #container .place {
-          overflow: hidden;
-          white-space: nowrap;
-          text-overflow: ellipsis;
-        }
-        #container .place-text {
-          /* Required for non-chrome browsers to actually show ellipsis */
-          display: inline;
-        }
         .col-1 {
           width: 38%;
         }
@@ -379,6 +370,9 @@ Example:
       }
 
       @media all and (max-width: 767px) {
+        #container {
+          height: 80px;
+        }
         #container, .col .title {
           font-size: 12px;
           line-height: 14px;
@@ -458,6 +452,20 @@ Example:
         -ms-flex-pack: center;
         -webkit-justify-content: center;
         justify-content: center;
+      }
+
+      @media all and (max-width: 375px) {
+        #container .place,
+        #container .place-text,
+        #container .add-styles,
+        #container .date {
+          height: 35px;
+          margin: 0px;
+          overflow: hidden;
+          display: -webkit-box;
+          -webkit-line-clamp: 2;
+          -webkit-box-orient: vertical;
+        }
       }
     </style>
     <iron-ajax id="postTitle"
@@ -548,8 +556,8 @@ Example:
               </a>
             </template>
             <template is='dom-if' if='[[data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place'>
-                <span> [[_getPlace(data.datesPlaces.0)]]</span>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place' title='[[_getPlace(data.datesPlaces.0)]]'>
+                <span>[[_getPlace(data.datesPlaces.0)]]</span>
               </a>
               <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='add-styles' hidden='[[_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place'>
                 <i class='add-icon'></i>[[i18n('add_place')]]

--- a/fs-artifact-list-item.html
+++ b/fs-artifact-list-item.html
@@ -536,7 +536,7 @@ Example:
         <div class='col col-2' hidden='[[_showMobileMessage(_displayMessage, mobile)]]'>
           <div class='date'>
             <template is='dom-if' if='[[!data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=date' class='date-text' on-tap='_stopProp' hidden='[[!_hideDateElements(data.datesPlaces.0)]]'>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=date' class='date-text' title='[[_getDate(data.datesPlaces.0)]]' on-tap='_stopProp' hidden='[[!_hideDateElements(data.datesPlaces.0)]]'>
                 <span>[[_getDate(data.datesPlaces.0)]]</span>
               </a>
             </template>
@@ -551,12 +551,12 @@ Example:
           </div>
           <div class='place'>
             <template is='dom-if' if='[[!data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopProp'>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' title='[[_getPlace(data.datesPlaces.0)]]' on-tap='_stopProp'>
                 <span> [[_getPlace(data.datesPlaces.0)]]</span>
               </a>
             </template>
             <template is='dom-if' if='[[data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place'>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place' title='[[_getPlace(data.datesPlaces.0)]]'>
                 <span>[[_getPlace(data.datesPlaces.0)]]</span>
               </a>
               <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='add-styles' hidden='[[_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopPropForStandards' data-standard-type='place'>
@@ -568,7 +568,7 @@ Example:
         <div class='col col-3' hidden='[[_showMobileMessage(_displayMessage, mobile)]]'>
           <div class='place'>
             <template is='dom-if' if='[[!data.editableByCaller]]'>
-              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopProp'>
+              <a href$='[[_href]][[_calcParams(view)]]&focus=place' class='place-text' title='[[_getPlace(data.datesPlaces.0)]]' hidden='[[!_hidePlaceElements(data.datesPlaces.0)]]' on-tap='_stopProp'>
                 <span> [[_getPlace(data.datesPlaces.0)]]</span>
               </a>
             </template>


### PR DESCRIPTION
* Adding same approach to add ellipsis to text that the title uses (aka. `line-clamp`)
* Increased height of list-item on mobile _only_
* Added missing `title` attribute to link (exists already on other links with data in file)
* Updating a couple css issues my editor was complaining about